### PR TITLE
Update yubikey-gpg-nixos.html

### DIFF
--- a/yubikey-gpg-nixos.html
+++ b/yubikey-gpg-nixos.html
@@ -433,7 +433,7 @@ ssb   rsa4096 2017-09-17 [A] [expires: 2018-09-17]
 
 <p>
 Note that instead of saying <b>sec</b>, it now says <b>sec#</b>. This means that the
-key is not stored somewhere else. Now we are ready to store the subkeys on
+key is now stored somewhere else. Now we are ready to store the subkeys on
 our Yubikey.
 </p>
 </div>


### PR DESCRIPTION
I believe a "not" had been used where a "now" should have been.
Before: "This means that the key is not stored somewhere else."
After: "This means that the key is now stored somewhere else."